### PR TITLE
[Add] overriding time with clock package

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ final isCrossing = timeRange.isCross(timeRange2);
 print('Time ranges are crossing: $isCrossing');
 ```
 
+### Override time with `clock` package
+
+```dart
+withClock(
+    Clock(() => DateTime.now().subtract(Duration(days: 10, minutes: 214))),
+    () {
+        print(clock.now());                    // 2022-06-21 16:28:46.366887
+        print(DateTime.now());                 // 2022-07-01 20:02:46.367579    
+        print('${Date.now()} ${Time.now()}');  // 6/21/2022 16:28:46                  
+    },
+);
+```
+
 ## Changelog
 
 Please see the [Changelog](CHANGELOG.md) page to know what's recently changed.

--- a/example/clock.dart
+++ b/example/clock.dart
@@ -1,0 +1,13 @@
+import 'package:clock/clock.dart';
+import 'package:date_time/date_time.dart';
+
+void main() {
+  withClock(
+    Clock(() => DateTime.now().subtract(Duration(days: 10, minutes: 214))),
+    () {
+      print(clock.now()); // 2022-06-21 16:28:46.366887
+      print(DateTime.now()); // 2022-07-01 20:02:46.367579
+      print('${Date.now()} ${Time.now()}'); // 6/21/2022 16:28:46
+    },
+  );
+}

--- a/lib/src/date.dart
+++ b/lib/src/date.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:date_time/src/extensions.dart';
 import 'package:intl/intl.dart';
 import 'package:quiver/core.dart';
@@ -75,7 +76,7 @@ class Date {
   /// ```dart
   /// var thisInstant = Date.now();
   /// ```
-  factory Date.now() => DateTime.now().date;
+  factory Date.now() => clock.now().date;
 
   /// Constructs a [Date] instance with current date in the
   /// UTC time zone.
@@ -83,10 +84,10 @@ class Date {
   /// ```dart
   /// var thisInstant = Date.nowUtc();
   /// ```
-  factory Date.nowUtc() => DateTime.now().toUtc().date;
+  factory Date.nowUtc() => clock.now().toUtc().date;
 
   /// Today
-  factory Date.today() => Date.from(DateTime.now());
+  factory Date.today() => Date.from(clock.now());
 
   /// Tomorrow
   factory Date.tomorrow() => Date.today().nextDay;

--- a/lib/src/time.dart
+++ b/lib/src/time.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: constant_identifier_names, prefer_constructors_over_static_methods
 
+import 'package:clock/clock.dart';
 import 'package:date_time/date_time.dart';
 import 'package:quiver/core.dart';
 
@@ -145,7 +146,7 @@ class Time {
 
   /// Now
   static Time now() {
-    final dt = DateTime.now();
+    final dt = clock.now();
     return Time(
       hour: dt.hour,
       minute: dt.minute,
@@ -155,7 +156,7 @@ class Time {
 
   /// UTC Now
   static Time get utcNow {
-    final dt = DateTime.now().toUtc();
+    final dt = clock.now().toUtc();
     return Time(
       hour: dt.hour,
       minute: dt.minute,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -51,7 +51,7 @@ packages:
     source: hosted
     version: "0.3.5"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   quiver: ^3.0.1+1
   intl: ^0.17.0
+  clock: ^1.1.0
 
 dev_dependencies:
   given_when_then_unit_test: ^0.0.7


### PR DESCRIPTION
It is now impossible (or rather inconvenient) to consistently test widgets that use either `Date.now()` or `Time.now()` because you can't set the time to a constant value. With this PR you will now be able to make widgets always use the very same date and time.